### PR TITLE
release: v0.6.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,15 +40,15 @@
     "js-yaml": "^3.14.1"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.18",
-    "@types/node": "^14.14.12",
+    "@types/jest": "^26.0.19",
+    "@types/node": "^14.14.13",
     "@typescript-eslint/eslint-plugin": "^4.9.1",
     "@typescript-eslint/parser": "^4.9.1",
     "eslint": "^7.15.0",
     "jest": "^26.6.3",
     "jest-circus": "^26.6.3",
     "ts-jest": "^26.4.4",
-    "typescript": "^4.1.2"
+    "typescript": "^4.1.3"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/github-action-test-helper",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Test helper for GitHub Actions.",
   "keywords": [
     "github",

--- a/yarn.lock
+++ b/yarn.lock
@@ -685,10 +685,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.x", "@types/jest@^26.0.18":
-  version "26.0.18"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.18.tgz#3c5f9228e9ac15bd42f903f1acf2ad6ea5ed73d9"
-  integrity sha512-scDPs+mELZgsFetTgBSsIxKGrlitn9t/d2ecP+S1QSIGD+31fkMBEftLfOAX5k3tU06/0PjreJIQ+gWEbbHqpw==
+"@types/jest@26.x", "@types/jest@^26.0.19":
+  version "26.0.19"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.19.tgz#e6fa1e3def5842ec85045bd5210e9bb8289de790"
+  integrity sha512-jqHoirTG61fee6v6rwbnEuKhpSKih0tuhqeFbCmMmErhtu3BYlOZaXWjffgOstMM4S/3iQD31lI5bGLTrs97yQ==
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
@@ -698,10 +698,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
-"@types/node@*", "@types/node@>= 8", "@types/node@^14.14.12":
-  version "14.14.12"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.12.tgz#0b1d86f8c40141091285dea02e4940df73bba43f"
-  integrity sha512-ASH8OPHMNlkdjrEdmoILmzFfsJICvhBsFfAum4aKZ/9U4B6M6tTmTPh+f3ttWdD74CEGV5XvXWkbyfSdXaTd7g==
+"@types/node@*", "@types/node@>= 8", "@types/node@^14.14.13":
+  version "14.14.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.13.tgz#9e425079799322113ae8477297ae6ef51b8e0cdf"
+  integrity sha512-vbxr0VZ8exFMMAjCW8rJwaya0dMCDyYW2ZRdTyjtrCvJoENMpdUHOT/eTzvgyA5ZnqRZ/sI0NwqAxNHKYokLJQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -4077,10 +4077,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update npm dependencies (5b884055a9f05a49e6e512d0f08ff6734d0703a6)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/github-action-test-helper/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>cli.js -u --packageFile package.json</em></summary>

```Shell
Upgrading /home/runner/work/github-action-test-helper/github-action-test-helper/package.json

 @types/jest   ^26.0.18  →   ^26.0.19     
 @types/node  ^14.14.12  →  ^14.14.13     
 typescript      ^4.1.2  →     ^4.1.3     

Run npm install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.2.1: The platform "linux" is incompatible with this module.
info "fsevents@2.2.1" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 12.47s.
```

### stderr:

```Shell
warning " > @octokit/plugin-rest-endpoint-methods@4.4.1" has unmet peer dependency "@octokit/core@>=3".
```

</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.2.1: The platform "linux" is incompatible with this module.
info "fsevents@2.2.1" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 375 new dependencies.
info Direct dependencies
├─ @actions/core@1.2.6
├─ @actions/github@4.0.0
├─ @octokit/plugin-rest-endpoint-methods@4.4.1
├─ @types/jest@26.0.19
├─ @typescript-eslint/eslint-plugin@4.9.1
├─ @typescript-eslint/parser@4.9.1
├─ eslint@7.15.0
├─ jest-circus@26.6.3
├─ jest@26.6.3
├─ ts-jest@26.4.4
└─ typescript@4.1.3
info All dependencies
├─ @actions/core@1.2.6
├─ @actions/github@4.0.0
├─ @actions/http-client@1.0.9
├─ @babel/core@7.12.10
├─ @babel/helper-function-name@7.10.4
├─ @babel/helper-get-function-arity@7.12.10
├─ @babel/helper-member-expression-to-functions@7.12.7
├─ @babel/helper-module-imports@7.12.5
├─ @babel/helper-module-transforms@7.12.1
├─ @babel/helper-optimise-call-expression@7.12.10
├─ @babel/helper-replace-supers@7.12.5
├─ @babel/helper-simple-access@7.12.1
├─ @babel/helpers@7.12.5
├─ @babel/highlight@7.10.4
├─ @babel/plugin-syntax-async-generators@7.8.4
├─ @babel/plugin-syntax-bigint@7.8.3
├─ @babel/plugin-syntax-class-properties@7.12.1
├─ @babel/plugin-syntax-import-meta@7.10.4
├─ @babel/plugin-syntax-json-strings@7.8.3
├─ @babel/plugin-syntax-logical-assignment-operators@7.10.4
├─ @babel/plugin-syntax-nullish-coalescing-operator@7.8.3
├─ @babel/plugin-syntax-numeric-separator@7.10.4
├─ @babel/plugin-syntax-object-rest-spread@7.8.3
├─ @babel/plugin-syntax-optional-catch-binding@7.8.3
├─ @babel/plugin-syntax-optional-chaining@7.8.3
├─ @babel/plugin-syntax-top-level-await@7.12.1
├─ @babel/template@7.12.7
├─ @bcoe/v8-coverage@0.2.3
├─ @cnakazawa/watch@1.0.4
├─ @eslint/eslintrc@0.2.2
├─ @istanbuljs/load-nyc-config@1.1.0
├─ @jest/globals@26.6.2
├─ @jest/reporters@26.6.2
├─ @jest/test-sequencer@26.6.3
├─ @nodelib/fs.scandir@2.1.3
├─ @nodelib/fs.stat@2.0.3
├─ @nodelib/fs.walk@1.2.4
├─ @octokit/auth-token@2.4.4
├─ @octokit/core@3.2.4
├─ @octokit/endpoint@6.0.10
├─ @octokit/graphql@4.5.8
├─ @octokit/openapi-types@2.0.0
├─ @octokit/plugin-paginate-rest@2.6.2
├─ @octokit/plugin-rest-endpoint-methods@4.4.1
├─ @octokit/request-error@2.0.4
├─ @octokit/request@5.4.12
├─ @sinonjs/commons@1.8.1
├─ @sinonjs/fake-timers@6.0.1
├─ @types/babel__core@7.1.12
├─ @types/babel__generator@7.6.2
├─ @types/babel__template@7.4.0
├─ @types/graceful-fs@4.1.4
├─ @types/istanbul-lib-coverage@2.0.3
├─ @types/istanbul-lib-report@3.0.0
├─ @types/istanbul-reports@3.0.0
├─ @types/jest@26.0.19
├─ @types/json-schema@7.0.6
├─ @types/normalize-package-data@2.4.0
├─ @types/prettier@2.1.5
├─ @types/stack-utils@2.0.0
├─ @types/yargs-parser@15.0.0
├─ @typescript-eslint/eslint-plugin@4.9.1
├─ @typescript-eslint/experimental-utils@4.9.1
├─ @typescript-eslint/parser@4.9.1
├─ acorn-globals@6.0.0
├─ acorn-jsx@5.3.1
├─ acorn-walk@7.2.0
├─ ajv@6.12.6
├─ ansi-colors@4.1.1
├─ anymatch@3.1.1
├─ argparse@1.0.10
├─ arr-flatten@1.1.0
├─ array-union@2.1.0
├─ asn1@0.2.4
├─ assign-symbols@1.0.0
├─ astral-regex@1.0.0
├─ asynckit@0.4.0
├─ atob@2.1.2
├─ aws-sign2@0.7.0
├─ aws4@1.11.0
├─ babel-jest@26.6.3
├─ babel-plugin-jest-hoist@26.6.2
├─ babel-preset-current-node-syntax@1.0.0
├─ babel-preset-jest@26.6.2
├─ balanced-match@1.0.0
├─ base@0.11.2
├─ bcrypt-pbkdf@1.0.2
├─ before-after-hook@2.1.0
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ browser-process-hrtime@1.0.0
├─ bs-logger@0.2.6
├─ bser@2.1.1
├─ buffer-from@1.1.1
├─ cache-base@1.0.1
├─ camelcase@5.3.1
├─ capture-exit@2.0.0
├─ caseless@0.12.0
├─ char-regex@1.0.2
├─ ci-info@2.0.0
├─ cjs-module-lexer@0.6.0
├─ class-utils@0.3.6
├─ cliui@6.0.0
├─ collection-visit@1.0.0
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ combined-stream@1.0.8
├─ concat-map@0.0.1
├─ convert-source-map@1.7.0
├─ copy-descriptor@0.1.1
├─ core-util-is@1.0.2
├─ cross-spawn@7.0.3
├─ cssom@0.4.4
├─ cssstyle@2.3.0
├─ dashdash@1.14.1
├─ data-urls@2.0.0
├─ decimal.js@10.2.1
├─ decode-uri-component@0.2.0
├─ dedent@0.7.0
├─ deep-is@0.1.3
├─ deepmerge@4.2.2
├─ delayed-stream@1.0.0
├─ detect-newline@3.1.0
├─ diff-sequences@26.6.2
├─ dir-glob@3.0.1
├─ doctrine@3.0.0
├─ domexception@2.0.1
├─ ecc-jsbn@0.1.2
├─ emittery@0.7.2
├─ emoji-regex@8.0.0
├─ end-of-stream@1.4.4
├─ enquirer@2.3.6
├─ error-ex@1.3.2
├─ escape-string-regexp@2.0.0
├─ escodegen@1.14.3
├─ eslint-scope@5.1.1
├─ eslint-utils@2.1.0
├─ eslint-visitor-keys@1.3.0
├─ eslint@7.15.0
├─ espree@7.3.1
├─ esprima@4.0.1
├─ esquery@1.3.1
├─ esrecurse@4.3.0
├─ estraverse@4.3.0
├─ execa@4.1.0
├─ expand-brackets@2.1.4
├─ extend@3.0.2
├─ extglob@2.0.4
├─ extsprintf@1.3.0
├─ fast-deep-equal@3.1.3
├─ fast-glob@3.2.4
├─ fast-levenshtein@2.0.6
├─ fastq@1.9.0
├─ file-entry-cache@6.0.0
├─ fill-range@7.0.1
├─ flat-cache@3.0.4
├─ flatted@3.1.0
├─ for-in@1.0.2
├─ forever-agent@0.6.1
├─ form-data@2.3.3
├─ fs.realpath@1.0.0
├─ function-bind@1.1.1
├─ gensync@1.0.0-beta.2
├─ get-caller-file@2.0.5
├─ get-package-type@0.1.0
├─ get-stream@5.2.0
├─ getpass@0.1.7
├─ glob-parent@5.1.1
├─ glob@7.1.6
├─ globby@11.0.1
├─ growly@1.3.0
├─ har-schema@2.0.0
├─ har-validator@5.1.5
├─ has-value@1.0.0
├─ has@1.0.3
├─ hosted-git-info@2.8.8
├─ html-encoding-sniffer@2.0.1
├─ html-escaper@2.0.2
├─ http-signature@1.2.0
├─ human-signals@1.1.1
├─ iconv-lite@0.4.24
├─ import-fresh@3.2.2
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ ip-regex@2.1.0
├─ is-accessor-descriptor@1.0.0
├─ is-arrayish@0.2.1
├─ is-core-module@2.2.0
├─ is-data-descriptor@1.0.0
├─ is-descriptor@1.0.2
├─ is-docker@2.1.1
├─ is-extglob@2.1.1
├─ is-glob@4.0.1
├─ is-plain-object@2.0.4
├─ is-potential-custom-element-name@1.0.0
├─ is-stream@2.0.0
├─ is-typedarray@1.0.0
├─ is-windows@1.0.2
├─ is-wsl@2.2.0
├─ isarray@1.0.0
├─ isstream@0.1.2
├─ istanbul-lib-instrument@4.0.3
├─ istanbul-lib-source-maps@4.0.0
├─ istanbul-reports@3.0.2
├─ jest-changed-files@26.6.2
├─ jest-circus@26.6.3
├─ jest-cli@26.6.3
├─ jest-docblock@26.0.0
├─ jest-environment-jsdom@26.6.2
├─ jest-environment-node@26.6.2
├─ jest-jasmine2@26.6.3
├─ jest-leak-detector@26.6.2
├─ jest-pnp-resolver@1.2.2
├─ jest-resolve-dependencies@26.6.3
├─ jest-serializer@26.6.2
├─ jest-util@26.6.2
├─ jest-watcher@26.6.2
├─ jest@26.6.3
├─ js-tokens@4.0.0
├─ jsdom@16.4.0
├─ jsesc@2.5.2
├─ json-parse-even-better-errors@2.3.1
├─ json-schema-traverse@0.4.1
├─ json-schema@0.2.3
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json-stringify-safe@5.0.1
├─ json5@2.1.3
├─ jsprim@1.4.1
├─ kind-of@3.2.2
├─ kleur@3.0.3
├─ leven@3.1.0
├─ lines-and-columns@1.1.6
├─ locate-path@5.0.0
├─ lodash.memoize@4.1.2
├─ lodash.sortby@4.7.0
├─ lru-cache@6.0.0
├─ make-dir@3.1.0
├─ make-error@1.3.6
├─ makeerror@1.0.11
├─ map-visit@1.0.0
├─ mime-db@1.44.0
├─ mime-types@2.1.27
├─ mimic-fn@2.1.0
├─ minimist@1.2.5
├─ mixin-deep@1.3.2
├─ mkdirp@1.0.4
├─ ms@2.1.2
├─ nanomatch@1.2.13
├─ nice-try@1.0.5
├─ node-fetch@2.6.1
├─ node-int64@0.4.0
├─ node-modules-regexp@1.0.0
├─ node-notifier@8.0.0
├─ normalize-package-data@2.5.0
├─ normalize-path@3.0.0
├─ npm-run-path@4.0.1
├─ nwsapi@2.2.0
├─ oauth-sign@0.9.0
├─ object-copy@0.1.0
├─ onetime@5.1.2
├─ optionator@0.9.1
├─ p-each-series@2.2.0
├─ p-finally@1.0.0
├─ p-limit@2.3.0
├─ p-locate@4.1.0
├─ p-try@2.2.0
├─ parent-module@1.0.1
├─ parse-json@5.1.0
├─ parse5@5.1.1
├─ pascalcase@0.1.1
├─ path-exists@4.0.0
├─ path-is-absolute@1.0.1
├─ path-key@2.0.1
├─ path-parse@1.0.6
├─ path-type@4.0.0
├─ performance-now@2.1.0
├─ picomatch@2.2.2
├─ pirates@4.0.1
├─ pkg-dir@4.2.0
├─ posix-character-classes@0.1.1
├─ progress@2.0.3
├─ prompts@2.4.0
├─ qs@6.5.2
├─ react-is@17.0.1
├─ read-pkg-up@7.0.1
├─ read-pkg@5.2.0
├─ regexpp@3.1.0
├─ remove-trailing-separator@1.1.0
├─ repeat-element@1.1.3
├─ request-promise-core@1.1.4
├─ request-promise-native@1.0.9
├─ request@2.88.2
├─ require-directory@2.1.1
├─ require-main-filename@2.0.0
├─ resolve-cwd@3.0.0
├─ resolve-url@0.2.1
├─ resolve@1.19.0
├─ ret@0.1.15
├─ reusify@1.0.4
├─ rimraf@3.0.2
├─ rsvp@4.8.5
├─ run-parallel@1.1.10
├─ safe-buffer@5.2.1
├─ safer-buffer@2.1.2
├─ sane@4.1.0
├─ saxes@5.0.1
├─ semver@7.3.4
├─ set-blocking@2.0.0
├─ set-value@2.0.1
├─ shebang-command@2.0.0
├─ shebang-regex@3.0.0
├─ shellwords@0.1.1
├─ sisteransi@1.0.5
├─ slice-ansi@2.1.0
├─ snapdragon-node@2.1.1
├─ snapdragon-util@3.0.1
├─ source-map-resolve@0.5.3
├─ source-map-support@0.5.19
├─ source-map-url@0.4.0
├─ source-map@0.6.1
├─ spdx-correct@3.1.1
├─ spdx-exceptions@2.3.0
├─ split-string@3.1.0
├─ sprintf-js@1.0.3
├─ sshpk@1.16.1
├─ static-extend@0.1.2
├─ stealthy-require@1.1.1
├─ string-width@4.2.0
├─ strip-bom@4.0.0
├─ strip-eof@1.0.0
├─ strip-final-newline@2.0.0
├─ strip-json-comments@3.1.1
├─ supports-hyperlinks@2.1.0
├─ symbol-tree@3.2.4
├─ table@5.4.6
├─ terminal-link@2.1.1
├─ test-exclude@6.0.0
├─ text-table@0.2.0
├─ tmpl@1.0.4
├─ to-fast-properties@2.0.0
├─ to-object-path@0.3.0
├─ to-regex-range@5.0.1
├─ tough-cookie@2.5.0
├─ tr46@2.0.2
├─ ts-jest@26.4.4
├─ tslib@1.14.1
├─ tunnel-agent@0.6.0
├─ tunnel@0.0.6
├─ tweetnacl@0.14.5
├─ type-detect@4.0.8
├─ typedarray-to-buffer@3.1.5
├─ typescript@4.1.3
├─ union-value@1.0.1
├─ unset-value@1.0.0
├─ uri-js@4.4.0
├─ urix@0.1.0
├─ use@3.1.1
├─ uuid@8.3.2
├─ v8-compile-cache@2.2.0
├─ v8-to-istanbul@7.0.0
├─ validate-npm-package-license@3.0.4
├─ verror@1.10.0
├─ w3c-hr-time@1.0.2
├─ w3c-xmlserializer@2.0.0
├─ walker@1.0.7
├─ which-module@2.0.0
├─ which@2.0.2
├─ word-wrap@1.2.3
├─ wrap-ansi@6.2.0
├─ write-file-atomic@3.0.3
├─ ws@7.4.1
├─ xmlchars@2.2.0
├─ y18n@4.0.1
├─ yallist@4.0.0
└─ yargs-parser@20.2.4
Done in 4.76s.
```

### stderr:

```Shell
warning jest > @jest/core > jest-config > jest-environment-jsdom > jsdom > request-promise-native@1.0.9: request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
warning jest > @jest/core > jest-config > jest-environment-jsdom > jsdom > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning jest > @jest/core > jest-config > jest-environment-jsdom > jsdom > request > har-validator@5.1.5: this library is no longer supported
warning jest > @jest/core > jest-haste-map > sane > micromatch > snapdragon > source-map-resolve > urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
warning jest > @jest/core > jest-haste-map > sane > micromatch > snapdragon > source-map-resolve > resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
warning " > @octokit/plugin-rest-endpoint-methods@4.4.1" has unmet peer dependency "@octokit/core@>=3".
```

</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.22.5
0 vulnerabilities found - Packages audited: 616
Done in 0.75s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)