### PR TITLE
release: v0.7.39

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^17.0.21",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.12.1",
-    "eslint": "^8.9.0",
+    "eslint": "^8.10.0",
     "jest": "^27.5.1",
     "jest-circus": "^27.5.1",
     "ts-jest": "^27.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/github-action-test-helper",
-  "version": "0.7.38",
+  "version": "0.7.39",
   "description": "Test helper for GitHub Actions.",
   "keywords": [
     "github",

--- a/yarn.lock
+++ b/yarn.lock
@@ -317,10 +317,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eslint/eslintrc@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.1.0.tgz#583d12dbec5d4f22f333f9669f7d0b7c7815b4d3"
-  integrity sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==
+"@eslint/eslintrc@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.2.0.tgz#7ce1547a5c46dfe56e1e45c3c9ed18038c721c6a"
+  integrity sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
@@ -1309,9 +1309,9 @@ domexception@^2.0.1:
     webidl-conversions "^5.0.0"
 
 electron-to-chromium@^1.4.71:
-  version "1.4.72"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.72.tgz#19b871f1da8be8199b2330d694fc84fcdb72ecd9"
-  integrity sha512-9LkRQwjW6/wnSfevR21a3k8sOJ+XWSH7kkzs9/EUenKmuDkndP3W9y1yCZpOxufwGbX3JV8glZZSDb4o95zwXQ==
+  version "1.4.73"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.73.tgz#422f6f514315bcace9615903e4a9b6b9fa283137"
+  integrity sha512-RlCffXkE/LliqfA5m29+dVDPB2r72y2D2egMMfIy3Le8ODrxjuZNVo4NIC2yPL01N4xb4nZQLwzi6Z5tGIGLnA==
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -1395,12 +1395,12 @@ eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
-eslint@^8.9.0:
-  version "8.9.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.9.0.tgz#a2a8227a99599adc4342fd9b854cb8d8d6412fdb"
-  integrity sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==
+eslint@^8.10.0:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.10.0.tgz#931be395eb60f900c01658b278e05b6dae47199d"
+  integrity sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==
   dependencies:
-    "@eslint/eslintrc" "^1.1.0"
+    "@eslint/eslintrc" "^1.2.0"
     "@humanwhocodes/config-array" "^0.9.2"
     ajv "^6.10.0"
     chalk "^4.0.0"


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update npm dependencies (679ec3624b1a6a733be24bbc69285754530847d1)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/github-action-test-helper/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>cli.js -u --packageFile package.json</em></summary>

```Shell
Using yarn
Upgrading /home/runner/work/github-action-test-helper/github-action-test-helper/package.json

 eslint  ^8.9.0  →  ^8.10.0     

Run yarn install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.17
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 10.54s.
```

### stderr:

```Shell
warning " > @octokit/plugin-rest-endpoint-methods@5.13.0" has unmet peer dependency "@octokit/core@>=3".
```

</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.22.17
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 290 new dependencies.
info Direct dependencies
├─ @actions/core@1.6.0
├─ @actions/github@5.0.0
├─ @octokit/plugin-rest-endpoint-methods@5.13.0
├─ @types/jest@27.4.1
├─ @types/js-yaml@4.0.5
├─ @typescript-eslint/eslint-plugin@5.12.1
├─ @typescript-eslint/parser@5.12.1
├─ eslint@8.10.0
├─ jest@27.5.1
├─ ts-jest@27.1.3
└─ typescript@4.5.5
info All dependencies
├─ @actions/core@1.6.0
├─ @actions/github@5.0.0
├─ @ampproject/remapping@2.1.2
├─ @babel/compat-data@7.17.0
├─ @babel/core@7.17.5
├─ @babel/helper-compilation-targets@7.16.7
├─ @babel/helper-function-name@7.16.7
├─ @babel/helper-get-function-arity@7.16.7
├─ @babel/helper-hoist-variables@7.16.7
├─ @babel/helper-module-imports@7.16.7
├─ @babel/helper-module-transforms@7.17.6
├─ @babel/helper-plugin-utils@7.16.7
├─ @babel/helper-simple-access@7.16.7
├─ @babel/helper-validator-option@7.16.7
├─ @babel/helpers@7.17.2
├─ @babel/highlight@7.16.10
├─ @babel/plugin-syntax-async-generators@7.8.4
├─ @babel/plugin-syntax-bigint@7.8.3
├─ @babel/plugin-syntax-class-properties@7.12.13
├─ @babel/plugin-syntax-import-meta@7.10.4
├─ @babel/plugin-syntax-json-strings@7.8.3
├─ @babel/plugin-syntax-logical-assignment-operators@7.10.4
├─ @babel/plugin-syntax-nullish-coalescing-operator@7.8.3
├─ @babel/plugin-syntax-numeric-separator@7.10.4
├─ @babel/plugin-syntax-object-rest-spread@7.8.3
├─ @babel/plugin-syntax-optional-catch-binding@7.8.3
├─ @babel/plugin-syntax-optional-chaining@7.8.3
├─ @babel/plugin-syntax-top-level-await@7.14.5
├─ @babel/plugin-syntax-typescript@7.16.7
├─ @bcoe/v8-coverage@0.2.3
├─ @eslint/eslintrc@1.2.0
├─ @humanwhocodes/config-array@0.9.5
├─ @humanwhocodes/object-schema@1.2.1
├─ @istanbuljs/load-nyc-config@1.1.0
├─ @jest/globals@27.5.1
├─ @jest/reporters@27.5.1
├─ @jest/test-sequencer@27.5.1
├─ @jridgewell/resolve-uri@3.0.5
├─ @jridgewell/sourcemap-codec@1.4.11
├─ @jridgewell/trace-mapping@0.3.4
├─ @nodelib/fs.scandir@2.1.5
├─ @nodelib/fs.stat@2.0.5
├─ @nodelib/fs.walk@1.2.8
├─ @octokit/auth-token@2.5.0
├─ @octokit/core@3.5.1
├─ @octokit/endpoint@6.0.12
├─ @octokit/graphql@4.8.0
├─ @octokit/openapi-types@11.2.0
├─ @octokit/plugin-paginate-rest@2.17.0
├─ @octokit/plugin-rest-endpoint-methods@5.13.0
├─ @octokit/request-error@2.1.0
├─ @sinonjs/commons@1.8.3
├─ @sinonjs/fake-timers@8.1.0
├─ @tootallnate/once@1.1.2
├─ @types/babel__core@7.1.18
├─ @types/babel__generator@7.6.4
├─ @types/babel__template@7.4.1
├─ @types/babel__traverse@7.14.2
├─ @types/graceful-fs@4.1.5
├─ @types/istanbul-lib-coverage@2.0.4
├─ @types/istanbul-lib-report@3.0.0
├─ @types/istanbul-reports@3.0.1
├─ @types/jest@27.4.1
├─ @types/js-yaml@4.0.5
├─ @types/json-schema@7.0.9
├─ @types/prettier@2.4.4
├─ @types/stack-utils@2.0.1
├─ @types/yargs-parser@20.2.1
├─ @types/yargs@16.0.4
├─ @typescript-eslint/eslint-plugin@5.12.1
├─ @typescript-eslint/parser@5.12.1
├─ @typescript-eslint/type-utils@5.12.1
├─ abab@2.0.5
├─ acorn-globals@6.0.0
├─ acorn-jsx@5.3.2
├─ acorn-walk@7.2.0
├─ acorn@8.7.0
├─ ajv@6.12.6
├─ ansi-styles@4.3.0
├─ anymatch@3.1.2
├─ argparse@2.0.1
├─ array-union@2.1.0
├─ asynckit@0.4.0
├─ babel-jest@27.5.1
├─ babel-plugin-jest-hoist@27.5.1
├─ babel-preset-jest@27.5.1
├─ balanced-match@1.0.2
├─ before-after-hook@2.2.2
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ browser-process-hrtime@1.0.0
├─ browserslist@4.19.3
├─ bs-logger@0.2.6
├─ bser@2.1.1
├─ buffer-from@1.1.2
├─ camelcase@6.3.0
├─ caniuse-lite@1.0.30001312
├─ char-regex@1.0.2
├─ cjs-module-lexer@1.2.2
├─ cliui@7.0.4
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ combined-stream@1.0.8
├─ concat-map@0.0.1
├─ convert-source-map@1.8.0
├─ cross-spawn@7.0.3
├─ cssom@0.4.4
├─ cssstyle@2.3.0
├─ data-urls@2.0.0
├─ decimal.js@10.3.1
├─ dedent@0.7.0
├─ deep-is@0.1.4
├─ deepmerge@4.2.2
├─ delayed-stream@1.0.0
├─ deprecation@2.3.1
├─ detect-newline@3.1.0
├─ diff-sequences@27.5.1
├─ dir-glob@3.0.1
├─ doctrine@3.0.0
├─ domexception@2.0.1
├─ electron-to-chromium@1.4.73
├─ emoji-regex@8.0.0
├─ error-ex@1.3.2
├─ escape-string-regexp@4.0.0
├─ escodegen@2.0.0
├─ eslint-scope@7.1.1
├─ eslint@8.10.0
├─ esprima@4.0.1
├─ esquery@1.4.0
├─ fast-deep-equal@3.1.3
├─ fast-glob@3.2.11
├─ fast-levenshtein@2.0.6
├─ fastq@1.13.0
├─ fb-watchman@2.0.1
├─ file-entry-cache@6.0.1
├─ fill-range@7.0.1
├─ find-up@4.1.0
├─ flat-cache@3.0.4
├─ flatted@3.2.5
├─ form-data@3.0.1
├─ fs.realpath@1.0.0
├─ function-bind@1.1.1
├─ gensync@1.0.0-beta.2
├─ get-caller-file@2.0.5
├─ get-package-type@0.1.0
├─ get-stream@6.0.1
├─ glob-parent@6.0.2
├─ glob@7.2.0
├─ globals@13.12.1
├─ globby@11.1.0
├─ has@1.0.3
├─ html-encoding-sniffer@2.0.1
├─ html-escaper@2.0.2
├─ http-proxy-agent@4.0.1
├─ https-proxy-agent@5.0.0
├─ human-signals@2.1.0
├─ iconv-lite@0.4.24
├─ import-fresh@3.3.0
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ is-arrayish@0.2.1
├─ is-core-module@2.8.1
├─ is-extglob@2.1.1
├─ is-fullwidth-code-point@3.0.0
├─ is-number@7.0.0
├─ is-potential-custom-element-name@1.0.1
├─ is-stream@2.0.1
├─ isexe@2.0.0
├─ istanbul-lib-instrument@5.1.0
├─ istanbul-lib-source-maps@4.0.1
├─ istanbul-reports@3.1.4
├─ jest-changed-files@27.5.1
├─ jest-cli@27.5.1
├─ jest-docblock@27.5.1
├─ jest-jasmine2@27.5.1
├─ jest-leak-detector@27.5.1
├─ jest-pnp-resolver@1.2.2
├─ jest-resolve-dependencies@27.5.1
├─ jest-serializer@27.5.1
├─ jest-util@27.5.1
├─ jest-watcher@27.5.1
├─ jest@27.5.1
├─ js-tokens@4.0.0
├─ jsdom@16.7.0
├─ jsesc@2.5.2
├─ json-parse-even-better-errors@2.3.1
├─ json-schema-traverse@0.4.1
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json5@2.2.0
├─ kleur@3.0.3
├─ leven@3.1.0
├─ lines-and-columns@1.2.4
├─ locate-path@5.0.0
├─ lodash.memoize@4.1.2
├─ lodash.merge@4.6.2
├─ lodash@4.17.21
├─ lru-cache@6.0.0
├─ make-dir@3.1.0
├─ make-error@1.3.6
├─ makeerror@1.0.12
├─ merge2@1.4.1
├─ mime-db@1.51.0
├─ mime-types@2.1.34
├─ mimic-fn@2.1.0
├─ minimist@1.2.5
├─ ms@2.1.2
├─ node-fetch@2.6.7
├─ node-int64@0.4.0
├─ node-releases@2.0.2
├─ normalize-path@3.0.0
├─ npm-run-path@4.0.1
├─ nwsapi@2.2.0
├─ onetime@5.1.2
├─ optionator@0.9.1
├─ p-limit@2.3.0
├─ p-locate@4.1.0
├─ p-try@2.2.0
├─ parent-module@1.0.1
├─ parse-json@5.2.0
├─ parse5@6.0.1
├─ path-exists@4.0.0
├─ path-is-absolute@1.0.1
├─ path-key@3.1.1
├─ path-parse@1.0.7
├─ path-type@4.0.0
├─ picocolors@1.0.0
├─ picomatch@2.3.1
├─ pirates@4.0.5
├─ pkg-dir@4.2.0
├─ prompts@2.4.2
├─ psl@1.8.0
├─ queue-microtask@1.2.3
├─ react-is@17.0.2
├─ require-directory@2.1.1
├─ resolve-cwd@3.0.0
├─ resolve.exports@1.1.0
├─ resolve@1.22.0
├─ reusify@1.0.4
├─ rimraf@3.0.2
├─ run-parallel@1.2.0
├─ safe-buffer@5.1.2
├─ safer-buffer@2.1.2
├─ saxes@5.0.1
├─ semver@6.3.0
├─ shebang-command@2.0.0
├─ shebang-regex@3.0.0
├─ signal-exit@3.0.7
├─ sisteransi@1.0.5
├─ source-map-support@0.5.21
├─ sprintf-js@1.0.3
├─ string-width@4.2.3
├─ strip-bom@4.0.0
├─ strip-final-newline@2.0.0
├─ supports-color@7.2.0
├─ supports-hyperlinks@2.2.0
├─ supports-preserve-symlinks-flag@1.0.0
├─ symbol-tree@3.2.4
├─ terminal-link@2.1.1
├─ test-exclude@6.0.0
├─ text-table@0.2.0
├─ tmpl@1.0.5
├─ to-fast-properties@2.0.0
├─ to-regex-range@5.0.1
├─ tough-cookie@4.0.0
├─ tr46@2.1.0
├─ ts-jest@27.1.3
├─ tslib@1.14.1
├─ tunnel@0.0.6
├─ type-detect@4.0.8
├─ type-fest@0.20.2
├─ typedarray-to-buffer@3.1.5
├─ typescript@4.5.5
├─ universalify@0.1.2
├─ uri-js@4.4.1
├─ v8-compile-cache@2.3.0
├─ v8-to-istanbul@8.1.1
├─ w3c-hr-time@1.0.2
├─ w3c-xmlserializer@2.0.0
├─ walker@1.0.8
├─ whatwg-url@8.7.0
├─ which@2.0.2
├─ word-wrap@1.2.3
├─ wrap-ansi@7.0.0
├─ write-file-atomic@3.0.3
├─ ws@7.5.7
├─ xmlchars@2.2.0
├─ y18n@5.0.8
├─ yallist@4.0.0
├─ yargs-parser@20.2.9
└─ yargs@16.2.0
Done in 6.15s.
```

### stderr:

```Shell
warning " > @octokit/plugin-rest-endpoint-methods@5.13.0" has unmet peer dependency "@octokit/core@>=3".
```

</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.22.17
0 vulnerabilities found - Packages audited: 440
Done in 0.66s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)