### PR TITLE
release: v0.11.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/github-action-test-helper",
-  "version": "0.11.16",
+  "version": "0.11.17",
   "description": "Test helper for GitHub Actions.",
   "keywords": [
     "github",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@rollup/plugin-typescript": "^11.1.1",
     "@sindresorhus/tsconfig": "^3.0.1",
     "@types/js-yaml": "^4.0.5",
-    "@types/node": "^20.2.3",
+    "@types/node": "^20.2.5",
     "@typescript-eslint/eslint-plugin": "^5.59.7",
     "@typescript-eslint/parser": "^5.59.7",
     "@vitest/coverage-c8": "^0.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,19 +400,19 @@
   integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
 
 "@types/json-schema@^7.0.9":
-  version "7.0.11"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
-  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+  version "7.0.12"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
+  integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/node@*", "@types/node@^20.2.3":
-  version "20.2.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.2.3.tgz#b31eb300610c3835ac008d690de6f87e28f9b878"
-  integrity sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw==
+"@types/node@*", "@types/node@^20.2.5":
+  version "20.2.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.2.5.tgz#26d295f3570323b2837d322180dfbf1ba156fefb"
+  integrity sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==
 
 "@types/semver@^7.3.12":
   version "7.5.0"
@@ -690,9 +690,9 @@ braces@^3.0.2:
     fill-range "^7.0.1"
 
 c8@^7.13.0:
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/c8/-/c8-7.13.0.tgz#a2a70a851278709df5a9247d62d7f3d4bcb5f2e4"
-  integrity sha512-/NL4hQTv1gBL6J6ei80zu3IiTrmePDKXKXOTLpHvcIWZTVYQlDhVWjjWvkhICylE8EwwnMVzDZugCvdx0/DIIA==
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/c8/-/c8-7.14.0.tgz#f368184c73b125a80565e9ab2396ff0be4d732f3"
+  integrity sha512-i04rtkkcNcCf7zsQcSv/T9EbUn4RXQ6mropeMcjFOsQXQ0iGLAr/xT6TImQg4+U9hmNpN9XdvPkjUL1IzbgxJw==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
     "@istanbuljs/schema" "^0.1.3"
@@ -1885,9 +1885,9 @@ pkg-types@^1.0.3:
     pathe "^1.1.0"
 
 postcss@^8.4.23:
-  version "8.4.23"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.23.tgz#df0aee9ac7c5e53e1075c24a3613496f9e6552ab"
-  integrity sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==
+  version "8.4.24"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.24.tgz#f714dba9b2284be3cc07dbd2fc57ee4dc972d2df"
+  integrity sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==
   dependencies:
     nanoid "^3.3.6"
     picocolors "^1.0.0"
@@ -2278,9 +2278,9 @@ vite-node@0.31.1:
     vite "^3.0.0 || ^4.0.0"
 
 "vite@^3.0.0 || ^4.0.0":
-  version "4.3.8"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-4.3.8.tgz#70cd6a294ab52d7fb8f37f5bc63d117dd19e9918"
-  integrity sha512-uYB8PwN7hbMrf4j1xzGDk/lqjsZvCDbt/JC5dyfxc19Pg8kRm14LinK/uq+HSLNswZEoKmweGdtpbnxRtrAXiQ==
+  version "4.3.9"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-4.3.9.tgz#db896200c0b1aa13b37cdc35c9e99ee2fdd5f96d"
+  integrity sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==
   dependencies:
     esbuild "^0.17.5"
     postcss "^8.4.23"


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update npm dependencies (d8e4e630411bcf35d71bf3242b892c79ffb7ab26)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/github-action-test-helper/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>cli.js -u --packageFile package.json</em></summary>

```Shell
Using yarn
Upgrading /home/runner/work/github-action-test-helper/github-action-test-helper/package.json

 @types/node  ^20.2.3  →  ^20.2.5

Run yarn install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 9.71s.
```



</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 244 new dependencies.
info Direct dependencies
├─ @actions/core@1.10.0
├─ @actions/github@5.1.1
├─ @rollup/plugin-typescript@11.1.1
├─ @sindresorhus/tsconfig@3.0.1
├─ @types/js-yaml@4.0.5
├─ @types/node@20.2.5
├─ @typescript-eslint/eslint-plugin@5.59.7
├─ @typescript-eslint/parser@5.59.7
├─ @vitest/coverage-c8@0.31.1
├─ eslint-plugin-import@2.27.5
├─ eslint@8.41.0
├─ rollup@3.23.0
├─ typescript@5.0.4
└─ vitest@0.31.1
info All dependencies
├─ @actions/core@1.10.0
├─ @actions/github@5.1.1
├─ @ampproject/remapping@2.2.1
├─ @bcoe/v8-coverage@0.2.3
├─ @esbuild/linux-x64@0.17.19
├─ @eslint/eslintrc@2.0.3
├─ @eslint/js@8.41.0
├─ @humanwhocodes/config-array@0.11.8
├─ @humanwhocodes/module-importer@1.0.1
├─ @humanwhocodes/object-schema@1.2.1
├─ @istanbuljs/schema@0.1.3
├─ @jridgewell/gen-mapping@0.3.3
├─ @jridgewell/resolve-uri@3.1.0
├─ @jridgewell/set-array@1.1.2
├─ @jridgewell/sourcemap-codec@1.4.15
├─ @jridgewell/trace-mapping@0.3.18
├─ @nodelib/fs.scandir@2.1.5
├─ @nodelib/fs.stat@2.0.5
├─ @nodelib/fs.walk@1.2.8
├─ @octokit/auth-token@2.5.0
├─ @octokit/core@3.6.0
├─ @octokit/endpoint@6.0.12
├─ @octokit/graphql@4.8.0
├─ @octokit/openapi-types@12.11.0
├─ @octokit/plugin-paginate-rest@2.21.3
├─ @octokit/plugin-rest-endpoint-methods@5.16.2
├─ @octokit/request-error@2.1.0
├─ @octokit/request@5.6.3
├─ @rollup/plugin-typescript@11.1.1
├─ @rollup/pluginutils@5.0.2
├─ @sindresorhus/tsconfig@3.0.1
├─ @types/chai-subset@1.3.3
├─ @types/chai@4.3.5
├─ @types/estree@1.0.1
├─ @types/istanbul-lib-coverage@2.0.4
├─ @types/js-yaml@4.0.5
├─ @types/json-schema@7.0.12
├─ @types/json5@0.0.29
├─ @types/node@20.2.5
├─ @types/semver@7.5.0
├─ @typescript-eslint/eslint-plugin@5.59.7
├─ @typescript-eslint/parser@5.59.7
├─ @typescript-eslint/type-utils@5.59.7
├─ @vitest/coverage-c8@0.31.1
├─ @vitest/expect@0.31.1
├─ @vitest/runner@0.31.1
├─ @vitest/snapshot@0.31.1
├─ acorn-jsx@5.3.2
├─ acorn-walk@8.2.0
├─ acorn@8.8.2
├─ ajv@6.12.6
├─ ansi-styles@4.3.0
├─ argparse@2.0.1
├─ array-buffer-byte-length@1.0.0
├─ array-includes@3.1.6
├─ array-union@2.1.0
├─ array.prototype.flat@1.3.1
├─ array.prototype.flatmap@1.3.1
├─ assertion-error@1.1.0
├─ balanced-match@1.0.2
├─ before-after-hook@2.2.3
├─ blueimp-md5@2.19.0
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ c8@7.14.0
├─ callsites@3.1.0
├─ chalk@4.1.2
├─ check-error@1.0.2
├─ cliui@7.0.4
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ concat-map@0.0.1
├─ convert-source-map@1.9.0
├─ cross-spawn@7.0.3
├─ date-time@3.1.0
├─ debug@4.3.4
├─ deep-eql@4.1.3
├─ deep-is@0.1.4
├─ define-properties@1.2.0
├─ deprecation@2.3.1
├─ dir-glob@3.0.1
├─ doctrine@2.1.0
├─ emoji-regex@8.0.0
├─ es-set-tostringtag@2.0.1
├─ es-to-primitive@1.2.1
├─ esbuild@0.17.19
├─ escalade@3.1.1
├─ escape-string-regexp@4.0.0
├─ eslint-import-resolver-node@0.3.7
├─ eslint-module-utils@2.8.0
├─ eslint-plugin-import@2.27.5
├─ eslint-scope@7.2.0
├─ eslint@8.41.0
├─ esquery@1.5.0
├─ estraverse@5.3.0
├─ estree-walker@2.0.2
├─ fast-deep-equal@3.1.3
├─ fast-diff@1.3.0
├─ fast-glob@3.2.12
├─ fast-json-stable-stringify@2.1.0
├─ fast-levenshtein@2.0.6
├─ fastq@1.15.0
├─ file-entry-cache@6.0.1
├─ fill-range@7.0.1
├─ flat-cache@3.0.4
├─ flatted@3.2.7
├─ foreground-child@2.0.0
├─ fs.realpath@1.0.0
├─ function.prototype.name@1.1.5
├─ functions-have-names@1.2.3
├─ get-caller-file@2.0.5
├─ get-symbol-description@1.0.0
├─ glob-parent@6.0.2
├─ glob@7.2.3
├─ globalthis@1.0.3
├─ globby@11.1.0
├─ grapheme-splitter@1.0.4
├─ graphemer@1.4.0
├─ has-bigints@1.0.2
├─ has-flag@4.0.0
├─ html-escaper@2.0.2
├─ import-fresh@3.3.0
├─ imurmurhash@0.1.4
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ internal-slot@1.0.5
├─ is-array-buffer@3.0.2
├─ is-bigint@1.0.4
├─ is-boolean-object@1.1.2
├─ is-callable@1.2.7
├─ is-date-object@1.0.5
├─ is-extglob@2.1.1
├─ is-fullwidth-code-point@3.0.0
├─ is-negative-zero@2.0.2
├─ is-number-object@1.0.7
├─ is-number@7.0.0
├─ is-path-inside@3.0.3
├─ is-shared-array-buffer@1.0.2
├─ is-string@1.0.7
├─ is-symbol@1.0.4
├─ is-typed-array@1.1.10
├─ is-weakref@1.0.2
├─ isexe@2.0.0
├─ istanbul-lib-coverage@3.2.0
├─ istanbul-reports@3.1.5
├─ js-string-escape@1.0.1
├─ json-schema-traverse@0.4.1
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json5@1.0.2
├─ jsonc-parser@3.2.0
├─ local-pkg@0.4.3
├─ locate-path@6.0.0
├─ lodash.merge@4.6.2
├─ lodash@4.17.21
├─ loupe@2.3.6
├─ lru-cache@6.0.0
├─ make-dir@3.1.0
├─ md5-hex@3.0.1
├─ merge2@1.4.1
├─ micromatch@4.0.5
├─ minimist@1.2.8
├─ ms@2.1.2
├─ nanoid@3.3.6
├─ natural-compare-lite@1.4.0
├─ natural-compare@1.4.0
├─ node-fetch@2.6.11
├─ object-inspect@1.12.3
├─ object.assign@4.1.4
├─ object.values@1.1.6
├─ optionator@0.9.1
├─ p-limit@4.0.0
├─ p-locate@5.0.0
├─ parent-module@1.0.1
├─ path-exists@4.0.0
├─ path-is-absolute@1.0.1
├─ path-key@3.1.1
├─ path-parse@1.0.7
├─ path-type@4.0.0
├─ pathval@1.1.1
├─ pkg-types@1.0.3
├─ postcss@8.4.24
├─ punycode@2.3.0
├─ queue-microtask@1.2.3
├─ react-is@17.0.2
├─ regexp.prototype.flags@1.5.0
├─ require-directory@2.1.1
├─ resolve-from@4.0.0
├─ reusify@1.0.4
├─ rollup@3.23.0
├─ run-parallel@1.2.0
├─ safe-regex-test@1.0.0
├─ shebang-command@2.0.0
├─ shebang-regex@3.0.0
├─ side-channel@1.0.4
├─ siginfo@2.0.0
├─ signal-exit@3.0.7
├─ slash@3.0.0
├─ source-map-js@1.0.2
├─ stackback@0.0.2
├─ string-width@4.2.3
├─ string.prototype.trim@1.2.7
├─ string.prototype.trimend@1.0.6
├─ string.prototype.trimstart@1.0.6
├─ strip-bom@3.0.0
├─ strip-json-comments@3.1.1
├─ strip-literal@1.0.1
├─ supports-preserve-symlinks-flag@1.0.0
├─ test-exclude@6.0.0
├─ text-table@0.2.0
├─ time-zone@1.0.0
├─ tinybench@2.5.0
├─ tinypool@0.5.0
├─ tinyspy@2.1.0
├─ to-regex-range@5.0.1
├─ tr46@0.0.3
├─ tsconfig-paths@3.14.2
├─ tslib@1.14.1
├─ tunnel@0.0.6
├─ type-check@0.4.0
├─ type-detect@4.0.8
├─ type-fest@0.20.2
├─ typed-array-length@1.0.4
├─ typescript@5.0.4
├─ ufo@1.1.2
├─ unbox-primitive@1.0.2
├─ uri-js@4.4.1
├─ uuid@8.3.2
├─ v8-to-istanbul@9.1.0
├─ vite-node@0.31.1
├─ vitest@0.31.1
├─ webidl-conversions@3.0.1
├─ well-known-symbols@2.0.0
├─ whatwg-url@5.0.0
├─ which-boxed-primitive@1.0.2
├─ which-typed-array@1.1.9
├─ which@2.0.2
├─ why-is-node-running@2.2.2
├─ word-wrap@1.2.3
├─ wrap-ansi@7.0.0
├─ y18n@5.0.8
├─ yallist@4.0.0
├─ yargs-parser@20.2.9
├─ yargs@16.2.0
└─ yocto-queue@1.0.0
Done in 6.91s.
```



</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.22.19
0 vulnerabilities found - Packages audited: 346
Done in 0.51s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)